### PR TITLE
Fix PostgreSQL 18+ error, remove unnecessary version

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   postgres:
     image: postgres
@@ -13,7 +11,7 @@ services:
     ports:
       - ${POSTGRES_PORT}:5432
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
       interval: 10s


### PR DESCRIPTION
Freshly starting the containers showed this error:
<img width="899" height="474" alt="Screenshot 2025-11-05 at 22 46 43" src="https://github.com/user-attachments/assets/6a800dda-bac5-44fd-9461-fc4c3ca8d6ec" />

It refers to this discussion: https://github.com/docker-library/postgres/issues/37, with a potential fix being this change: https://github.com/docker-library/postgres/issues/37#issuecomment-3476426533

I made these changes in this PR, including removing the deprecated version line from the compose: https://forums.docker.com/t/docker-compose-yml-version-is-obsolete/141313

Now, the containers are working correctly:
<img width="1053" height="589" alt="Screenshot 2025-11-05 at 22 49 41" src="https://github.com/user-attachments/assets/0a38ed9e-e971-4bbf-87e4-733fa4ce8e1a" />
